### PR TITLE
feat: Add architecture dependencies and sample ProfileScreen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,22 @@ KataLLMAndroid is an Android application that displays a list of Large Language 
 
 ## Architecture
 
-This is a standard single-module Android application using Jetpack Compose for UI.
+This App will have the following architecture and best practices for Android development 
 
-**Current Structure:**
-- `MainActivity`: Single entry point with Compose UI
-- `ui/theme/`: Compose theming (Color, Theme, Type)
+- MVVM / MVI for propagating ViewModel state to a UI written in Jetpack Compose
+- kotlinx.coroutines and Flow for handling asynchronous and concurrent implementations
+- Hilt for Dependency Injection
+- Material Design (Material3) as the design system. Standard Android UI components will be priority, rather than custom ones
+- retrofit and okhttp for network requests
+- gson for parsing JSON objects
+- For the moment, we will use a single module called "app". This may change in the future and we may want to modularize the App by layer and by feature.
+- A simple architecture without unnecessary extra layers: UI (Activity/Fragment/Screen) - ViewModel - [UseCase] - [Repository] - Data Source
+- The repository Layer will be optional. There will be no interfaces with one single implementation. If there is only one implementation, we will use a class.
+- All UseCases, Repositories and Data Sources will return Flow. This way, we will be able to perform collection operations with them.
+- The ViewModel layer will use kotlinx.coroutines or extension functions that wrap them to handle concurrency.
+- UseCases can also be omitted if they only contain a single call to the Repository/DataSource. ViewModel can directly call the Repository/DataSource and we save layers in that case.
+- Every screen will have a @Composable class called *Screen and a ViewModel called *ViewModel. For example ProfileScreen, ProfileViewModel. 
+- Every ViewModel class will have a Unit Test class associated that will at least contain tests to assert collaborations between the ViewModel and external collaborators (UC, Repositories, DS)
 
 The project uses:
 - Version Catalog (`gradle/libs.versions.toml`) for centralized dependency management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,7 @@ All dependencies are managed via the version catalog in `gradle/libs.versions.to
 - For short stories, prefer rebase over merge. If branch has more commits, use merge instead of rebase to slightly minimize merge conflicts.
 - In case there are merge conflicts, inform about them, rather than resolving them.
 - When pushing a branch, do not forget to set the upstream, so the next time we can directly use "git push" in this branch instead of specifying the origin and the destination branch
+
+## Pull Requests
+
+- For every PR that is opened, check for available Android devices by running `adb devices`. If a connected device is found, install the debug APK on it using `./gradlew installDebug` to verify the build can be installed successfully on a real device or emulator.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ All dependencies are managed via the version catalog in `gradle/libs.versions.to
 
 - All text files must end with a newline character
 - Package structure: `es.voghdev.katallmandroid`
+- Do not add unnecessary comments in code or configuration files unless they are completely essential, such as documenting known bugs or critical issues in code or libraries
 
 ## VCS / Git
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt.android)
 }
 
 android {
@@ -49,7 +51,34 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
+
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.android.compiler)
+    implementation(libs.hilt.navigation.compose)
+
+    // Navigation
+    implementation(libs.androidx.navigation.compose)
+
+    // Retrofit + OkHttp + Gson
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.converter.gson)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.gson)
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.android)
+
+    // ViewModel Compose
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,28 +53,18 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material.icons.extended)
 
-    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.navigation.compose)
-
-    // Navigation
     implementation(libs.androidx.navigation.compose)
-
-    // Retrofit + OkHttp + Gson
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.gson)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.gson)
-
-    // Coroutines
     implementation(libs.kotlinx.coroutines.android)
-
-    // ViewModel Compose
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    // Testing
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.turbine)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".KataLLMAndroidApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/es/voghdev/katallmandroid/KataLLMAndroidApp.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/KataLLMAndroidApp.kt
@@ -1,0 +1,7 @@
+package es.voghdev.katallmandroid
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class KataLLMAndroidApp : Application()

--- a/app/src/main/java/es/voghdev/katallmandroid/MainActivity.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/MainActivity.kt
@@ -6,27 +6,65 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import dagger.hilt.android.AndroidEntryPoint
+import es.voghdev.katallmandroid.navigation.AppNavigation
 import es.voghdev.katallmandroid.ui.theme.KataLLMAndroidTheme
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             KataLLMAndroidTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                AppNavigation { onNavigateToProfile ->
+                    HomeScreen(onNavigateToProfile = onNavigateToProfile)
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(onNavigateToProfile: () -> Unit = {}) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("KataLLM") },
+                actions = {
+                    IconButton(onClick = onNavigateToProfile) {
+                        Icon(
+                            imageVector = Icons.Filled.Person,
+                            contentDescription = "Profile",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        Greeting(
+            name = "Android",
+            modifier = Modifier.padding(innerPadding),
+        )
     }
 }
 
@@ -34,14 +72,14 @@ class MainActivity : ComponentActivity() {
 fun Greeting(name: String, modifier: Modifier = Modifier) {
     Text(
         text = "Hello $name!",
-        modifier = modifier
+        modifier = modifier,
     )
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun HomeScreenPreview() {
     KataLLMAndroidTheme {
-        Greeting("Android")
+        HomeScreen()
     }
 }

--- a/app/src/main/java/es/voghdev/katallmandroid/features/profile/data/ProfileDataSource.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/profile/data/ProfileDataSource.kt
@@ -1,0 +1,18 @@
+package es.voghdev.katallmandroid.features.profile.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class ProfileDataSource @Inject constructor() {
+    fun getUser(): Flow<User> = flow {
+        emit(
+            User(
+                name = "Jane Doe",
+                address = "742 Evergreen Terrace, Springfield",
+                phoneNumber = "+1 (555) 123-4567",
+                profilePictureUrl = "",
+            )
+        )
+    }
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/features/profile/data/User.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/profile/data/User.kt
@@ -1,0 +1,8 @@
+package es.voghdev.katallmandroid.features.profile.data
+
+data class User(
+    val name: String,
+    val address: String,
+    val phoneNumber: String,
+    val profilePictureUrl: String,
+)

--- a/app/src/main/java/es/voghdev/katallmandroid/features/profile/ui/ProfileScreen.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/profile/ui/ProfileScreen.kt
@@ -1,0 +1,204 @@
+package es.voghdev.katallmandroid.features.profile.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import es.voghdev.katallmandroid.features.profile.data.User
+import es.voghdev.katallmandroid.ui.theme.KataLLMAndroidTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    onNavigateBack: () -> Unit = {},
+    viewModel: ProfileViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Profile") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is ProfileUiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is ProfileUiState.Success -> {
+                ProfileContent(
+                    user = state.user,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            is ProfileUiState.Error -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = state.message,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileContent(user: User, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Placeholder profile picture
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Person,
+                contentDescription = "Profile picture",
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = user.name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                ProfileInfoRow(
+                    icon = { Icon(Icons.Filled.Home, contentDescription = "Address") },
+                    label = "Address",
+                    value = user.address,
+                )
+                ProfileInfoRow(
+                    icon = { Icon(Icons.Filled.Phone, contentDescription = "Phone") },
+                    label = "Phone",
+                    value = user.phoneNumber,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileInfoRow(
+    icon: @Composable () -> Unit,
+    label: String,
+    value: String,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        icon()
+        Column {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProfileContentPreview() {
+    KataLLMAndroidTheme {
+        ProfileContent(
+            user = User(
+                name = "Jane Doe",
+                address = "742 Evergreen Terrace, Springfield",
+                phoneNumber = "+1 (555) 123-4567",
+                profilePictureUrl = "",
+            ),
+        )
+    }
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/features/profile/ui/ProfileViewModel.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/profile/ui/ProfileViewModel.kt
@@ -1,0 +1,39 @@
+package es.voghdev.katallmandroid.features.profile.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import es.voghdev.katallmandroid.features.profile.data.ProfileDataSource
+import es.voghdev.katallmandroid.features.profile.data.User
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val profileDataSource: ProfileDataSource,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ProfileUiState>(ProfileUiState.Loading)
+    val uiState: StateFlow<ProfileUiState> = _uiState
+
+    init {
+        loadProfile()
+    }
+
+    private fun loadProfile() {
+        viewModelScope.launch {
+            profileDataSource.getUser()
+                .catch { _uiState.value = ProfileUiState.Error(it.message ?: "Unknown error") }
+                .collect { user -> _uiState.value = ProfileUiState.Success(user) }
+        }
+    }
+}
+
+sealed interface ProfileUiState {
+    data object Loading : ProfileUiState
+    data class Success(val user: User) : ProfileUiState
+    data class Error(val message: String) : ProfileUiState
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
@@ -1,0 +1,26 @@
+package es.voghdev.katallmandroid.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import es.voghdev.katallmandroid.features.profile.ui.ProfileScreen
+
+object Routes {
+    const val HOME = "home"
+    const val PROFILE = "profile"
+}
+
+@Composable
+fun AppNavigation(homeContent: @Composable (onNavigateToProfile: () -> Unit) -> Unit) {
+    val navController = rememberNavController()
+
+    NavHost(navController = navController, startDestination = Routes.HOME) {
+        composable(Routes.HOME) {
+            homeContent { navController.navigate(Routes.PROFILE) }
+        }
+        composable(Routes.PROFILE) {
+            ProfileScreen(onNavigateBack = { navController.popBackStack() })
+        }
+    }
+}

--- a/app/src/test/java/es/voghdev/katallmandroid/features/profile/ui/ProfileViewModelTest.kt
+++ b/app/src/test/java/es/voghdev/katallmandroid/features/profile/ui/ProfileViewModelTest.kt
@@ -1,0 +1,86 @@
+package es.voghdev.katallmandroid.features.profile.ui
+
+import app.cash.turbine.test
+import es.voghdev.katallmandroid.features.profile.data.ProfileDataSource
+import es.voghdev.katallmandroid.features.profile.data.User
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var profileDataSource: ProfileDataSource
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        profileDataSource = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `should fetch user from data source on init`() = runTest {
+        val expectedUser = User(
+            name = "Jane Doe",
+            address = "742 Evergreen Terrace, Springfield",
+            phoneNumber = "+1 (555) 123-4567",
+            profilePictureUrl = "",
+        )
+
+        every { profileDataSource.getUser() } returns flow { emit(expectedUser) }
+
+        val viewModel = ProfileViewModel(profileDataSource)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(ProfileUiState.Success(expectedUser), state)
+        }
+
+        verify { profileDataSource.getUser() }
+    }
+
+    @Test
+    fun `should emit error state when data source fails`() = runTest {
+        every { profileDataSource.getUser() } returns flow { throw RuntimeException("Network error") }
+
+        val viewModel = ProfileViewModel(profileDataSource)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(ProfileUiState.Error("Network error"), state)
+        }
+
+        verify { profileDataSource.getUser() }
+    }
+
+    @Test
+    fun `should start with loading state`() = runTest {
+        every { profileDataSource.getUser() } returns flow { /* never emits */ }
+
+        val viewModel = ProfileViewModel(profileDataSource)
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(ProfileUiState.Loading, state)
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt.android) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,29 +38,18 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 
-# Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
-
-# Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
-
-# Retrofit + OkHttp + Gson
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-
-# Coroutines
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
-
-# ViewModel Compose
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
-
-# Testing
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.9.1"
 kotlin = "2.0.21"
+ksp = "2.0.21-1.0.28"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -8,6 +9,17 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.09.00"
+hilt = "2.51.1"
+hiltNavigationCompose = "1.2.0"
+navigationCompose = "2.8.5"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+gson = "2.11.0"
+coroutines = "1.8.1"
+lifecycleViewmodelCompose = "2.8.7"
+mockk = "1.13.13"
+turbine = "1.2.0"
+materialIconsExtended = "1.7.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,9 +36,37 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
+
+# Hilt
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+# Navigation
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Retrofit + OkHttp + Gson
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+
+# Coroutines
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+
+# ViewModel Compose
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
+
+# Testing
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
## Summary
- Add Hilt, Navigation Compose, Retrofit, OkHttp, Gson, Coroutines, and testing libs (MockK, Turbine) to the version catalog and build files
- Create a sample ProfileScreen with ProfileViewModel following MVVM: Screen -> ViewModel -> DataSource (Flow-based)
- Profile displays a placeholder picture, name, address, and phone number from a stubbed `ProfileDataSource`
- Configure Hilt DI (`@HiltAndroidApp`, `@AndroidEntryPoint`, `@HiltViewModel`)
- Add TopAppBar with profile icon in HomeScreen, navigating to ProfileScreen via Jetpack Navigation Compose
- Remove unnecessary comments from build.gradle.kts, app/build.gradle.kts, and libs.versions.toml
- Update CLAUDE.md: add code style rule to avoid unnecessary comments, and add PR guideline to check for connected Android devices and install the debug APK via `./gradlew installDebug`

## Test plan
- [x] Project builds successfully (`./gradlew assembleDebug`)
- [x] All unit tests pass (`./gradlew testDebugUnitTest`)
- [x] ProfileViewModelTest covers: loading state, success state with user data, error state
- [ ] Manual: Launch app, verify TopAppBar with profile icon appears
- [ ] Manual: Tap profile icon, verify navigation to ProfileScreen
- [ ] Manual: Verify profile displays placeholder avatar, name, address, and phone

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)