### PR TITLE
Implement LLM list on Home Screen with detail navigation

### DIFF
--- a/app/src/main/java/es/voghdev/katallmandroid/MainActivity.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/MainActivity.kt
@@ -4,22 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import dagger.hilt.android.AndroidEntryPoint
+import es.voghdev.katallmandroid.features.home.ui.HomeScreen
 import es.voghdev.katallmandroid.navigation.AppNavigation
 import es.voghdev.katallmandroid.ui.theme.KataLLMAndroidTheme
 
@@ -30,56 +16,13 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             KataLLMAndroidTheme {
-                AppNavigation { onNavigateToProfile ->
-                    HomeScreen(onNavigateToProfile = onNavigateToProfile)
+                AppNavigation { onNavigateToProfile, onNavigateToLlmDetail ->
+                    HomeScreen(
+                        onNavigateToProfile = onNavigateToProfile,
+                        onNavigateToLlmDetail = onNavigateToLlmDetail,
+                    )
                 }
             }
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun HomeScreen(onNavigateToProfile: () -> Unit = {}) {
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        topBar = {
-            TopAppBar(
-                title = { Text("KataLLM") },
-                actions = {
-                    IconButton(onClick = onNavigateToProfile) {
-                        Icon(
-                            imageVector = Icons.Filled.Person,
-                            contentDescription = "Profile",
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
-            )
-        },
-    ) { innerPadding ->
-        Greeting(
-            name = "Android",
-            modifier = Modifier.padding(innerPadding),
-        )
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier,
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun HomeScreenPreview() {
-    KataLLMAndroidTheme {
-        HomeScreen()
     }
 }

--- a/app/src/main/java/es/voghdev/katallmandroid/features/home/data/Llm.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/home/data/Llm.kt
@@ -1,0 +1,8 @@
+package es.voghdev.katallmandroid.features.home.data
+
+data class Llm(
+    val name: String,
+    val company: String,
+    val releaseDate: String,
+    val description: String,
+)

--- a/app/src/main/java/es/voghdev/katallmandroid/features/home/data/LlmDataSource.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/home/data/LlmDataSource.kt
@@ -1,0 +1,58 @@
+package es.voghdev.katallmandroid.features.home.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LlmDataSource @Inject constructor() {
+    fun getLlms(): Flow<List<Llm>> = flow {
+        emit(
+            listOf(
+                Llm(
+                    name = "Claude Sonnet 4",
+                    company = "Anthropic",
+                    releaseDate = "2025-05",
+                    description = "Anthropic's balanced model offering strong performance across coding, analysis, and creative tasks with fast response times.",
+                ),
+                Llm(
+                    name = "Claude Opus 4",
+                    company = "Anthropic",
+                    releaseDate = "2025-05",
+                    description = "Anthropic's most capable model, excelling at complex reasoning, research, and nuanced content generation.",
+                ),
+                Llm(
+                    name = "Gemini 2.5 Pro",
+                    company = "Google DeepMind",
+                    releaseDate = "2025-03",
+                    description = "Google's advanced multimodal model with a large context window and strong reasoning capabilities.",
+                ),
+                Llm(
+                    name = "o1",
+                    company = "OpenAI",
+                    releaseDate = "2024-12",
+                    description = "OpenAI's reasoning-focused model that uses chain-of-thought to solve complex math, science, and coding problems.",
+                ),
+                Llm(
+                    name = "GPT-4o",
+                    company = "OpenAI",
+                    releaseDate = "2024-05",
+                    description = "OpenAI's versatile multimodal model supporting text, vision, and audio with fast inference.",
+                ),
+                Llm(
+                    name = "GPT-5",
+                    company = "OpenAI",
+                    releaseDate = "2025-06",
+                    description = "OpenAI's next-generation flagship model with improved reasoning and broader knowledge capabilities.",
+                ),
+                Llm(
+                    name = "Llama 4 Maverick",
+                    company = "Meta",
+                    releaseDate = "2025-04",
+                    description = "Meta's open-weight mixture-of-experts model offering strong multilingual and coding performance.",
+                ),
+            )
+        )
+    }
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/features/home/ui/HomeScreen.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/home/ui/HomeScreen.kt
@@ -1,0 +1,117 @@
+package es.voghdev.katallmandroid.features.home.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import es.voghdev.katallmandroid.features.home.data.Llm
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    onNavigateToProfile: () -> Unit = {},
+    onNavigateToLlmDetail: (Int) -> Unit = {},
+    viewModel: HomeViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("KataLLM") },
+                actions = {
+                    IconButton(onClick = onNavigateToProfile) {
+                        Icon(
+                            imageVector = Icons.Filled.Person,
+                            contentDescription = "Profile",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is HomeUiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is HomeUiState.Success -> {
+                LlmList(
+                    llms = state.llms,
+                    onLlmClick = onNavigateToLlmDetail,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            is HomeUiState.Error -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = state.message,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LlmList(
+    llms: List<Llm>,
+    onLlmClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        itemsIndexed(llms) { index, llm ->
+            LlmListItem(llm = llm, onClick = { onLlmClick(index) })
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun LlmListItem(llm: Llm, onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(llm.name) },
+        supportingContent = { Text(llm.company) },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/features/home/ui/HomeViewModel.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/home/ui/HomeViewModel.kt
@@ -1,0 +1,39 @@
+package es.voghdev.katallmandroid.features.home.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import es.voghdev.katallmandroid.features.home.data.Llm
+import es.voghdev.katallmandroid.features.home.data.LlmDataSource
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val llmDataSource: LlmDataSource,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+    val uiState: StateFlow<HomeUiState> = _uiState
+
+    init {
+        loadLlms()
+    }
+
+    private fun loadLlms() {
+        viewModelScope.launch {
+            llmDataSource.getLlms()
+                .catch { _uiState.value = HomeUiState.Error(it.message ?: "Unknown error") }
+                .collect { llms -> _uiState.value = HomeUiState.Success(llms) }
+        }
+    }
+}
+
+sealed interface HomeUiState {
+    data object Loading : HomeUiState
+    data class Success(val llms: List<Llm>) : HomeUiState
+    data class Error(val message: String) : HomeUiState
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/features/llmdetail/ui/LlmDetailScreen.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/llmdetail/ui/LlmDetailScreen.kt
@@ -1,0 +1,146 @@
+package es.voghdev.katallmandroid.features.llmdetail.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import es.voghdev.katallmandroid.features.home.data.Llm
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LlmDetailScreen(
+    llmIndex: Int,
+    onNavigateBack: () -> Unit = {},
+    viewModel: LlmDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(llmIndex) {
+        viewModel.loadLlm(llmIndex)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("LLM Detail") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is LlmDetailUiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is LlmDetailUiState.Success -> {
+                LlmDetailContent(
+                    llm = state.llm,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            is LlmDetailUiState.Error -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = state.message,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LlmDetailContent(llm: Llm, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = llm.name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                LlmDetailRow(label = "Company", value = llm.company)
+                LlmDetailRow(label = "Release Date", value = llm.releaseDate)
+                LlmDetailRow(label = "Description", value = llm.description)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LlmDetailRow(label: String, value: String) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/features/llmdetail/ui/LlmDetailViewModel.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/features/llmdetail/ui/LlmDetailViewModel.kt
@@ -1,0 +1,42 @@
+package es.voghdev.katallmandroid.features.llmdetail.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import es.voghdev.katallmandroid.features.home.data.Llm
+import es.voghdev.katallmandroid.features.home.data.LlmDataSource
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LlmDetailViewModel @Inject constructor(
+    private val llmDataSource: LlmDataSource,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<LlmDetailUiState>(LlmDetailUiState.Loading)
+    val uiState: StateFlow<LlmDetailUiState> = _uiState
+
+    fun loadLlm(index: Int) {
+        viewModelScope.launch {
+            llmDataSource.getLlms()
+                .catch { _uiState.value = LlmDetailUiState.Error(it.message ?: "Unknown error") }
+                .collect { llms ->
+                    val llm = llms.getOrNull(index)
+                    _uiState.value = if (llm != null) {
+                        LlmDetailUiState.Success(llm)
+                    } else {
+                        LlmDetailUiState.Error("LLM not found")
+                    }
+                }
+        }
+    }
+}
+
+sealed interface LlmDetailUiState {
+    data object Loading : LlmDetailUiState
+    data class Success(val llm: Llm) : LlmDetailUiState
+    data class Error(val message: String) : LlmDetailUiState
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
@@ -1,26 +1,48 @@
 package es.voghdev.katallmandroid.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import es.voghdev.katallmandroid.features.llmdetail.ui.LlmDetailScreen
 import es.voghdev.katallmandroid.features.profile.ui.ProfileScreen
 
 object Routes {
     const val HOME = "home"
     const val PROFILE = "profile"
+    const val LLM_DETAIL = "llm_detail/{llmIndex}"
 }
 
 @Composable
-fun AppNavigation(homeContent: @Composable (onNavigateToProfile: () -> Unit) -> Unit) {
+fun AppNavigation(
+    homeContent: @Composable (
+        onNavigateToProfile: () -> Unit,
+        onNavigateToLlmDetail: (Int) -> Unit,
+    ) -> Unit,
+) {
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = Routes.HOME) {
         composable(Routes.HOME) {
-            homeContent { navController.navigate(Routes.PROFILE) }
+            homeContent(
+                { navController.navigate(Routes.PROFILE) },
+                { index -> navController.navigate("llm_detail/$index") },
+            )
         }
         composable(Routes.PROFILE) {
             ProfileScreen(onNavigateBack = { navController.popBackStack() })
+        }
+        composable(
+            route = Routes.LLM_DETAIL,
+            arguments = listOf(navArgument("llmIndex") { type = NavType.IntType }),
+        ) { backStackEntry ->
+            val llmIndex = backStackEntry.arguments?.getInt("llmIndex") ?: 0
+            LlmDetailScreen(
+                llmIndex = llmIndex,
+                onNavigateBack = { navController.popBackStack() },
+            )
         }
     }
 }

--- a/app/src/test/java/es/voghdev/katallmandroid/features/home/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/es/voghdev/katallmandroid/features/home/ui/HomeViewModelTest.kt
@@ -1,0 +1,87 @@
+package es.voghdev.katallmandroid.features.home.ui
+
+import app.cash.turbine.test
+import es.voghdev.katallmandroid.features.home.data.Llm
+import es.voghdev.katallmandroid.features.home.data.LlmDataSource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var llmDataSource: LlmDataSource
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        llmDataSource = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `should start with loading state`() = runTest {
+        every { llmDataSource.getLlms() } returns flow { }
+
+        val viewModel = HomeViewModel(llmDataSource)
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(HomeUiState.Loading, state)
+        }
+    }
+
+    @Test
+    fun `should fetch llms from data source on init`() = runTest {
+        val expectedLlms = listOf(
+            Llm(
+                name = "Claude Sonnet 4",
+                company = "Anthropic",
+                releaseDate = "2025-05",
+                description = "A balanced model",
+            ),
+        )
+        every { llmDataSource.getLlms() } returns flow { emit(expectedLlms) }
+
+        val viewModel = HomeViewModel(llmDataSource)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(HomeUiState.Success(expectedLlms), state)
+        }
+
+        verify { llmDataSource.getLlms() }
+    }
+
+    @Test
+    fun `should emit error state when data source fails`() = runTest {
+        every { llmDataSource.getLlms() } returns flow { throw RuntimeException("Network error") }
+
+        val viewModel = HomeViewModel(llmDataSource)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertEquals(HomeUiState.Error("Network error"), state)
+        }
+
+        verify { llmDataSource.getLlms() }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace placeholder greeting on HomeScreen with a `LazyColumn` displaying 7 LLMs (Claude Sonnet, Claude Opus, Gemini 2.5 Pro, o1, GPT-4o, GPT-5, Llama 4 Maverick)
- Add `LlmDetailScreen` showing all fields (name, company, release date, description) when tapping an item
- Follow existing MVVM architecture: `HomeViewModel` + `LlmDataSource` with Hilt DI and Flow-based data
- Preserve existing TopAppBar with profile icon navigation
- Add `HomeViewModelTest` with 3 tests covering loading, success, and error states

## Screenshots

| LLM List | LLM Detail |
|:---:|:---:|
| <img src="https://raw.githubusercontent.com/voghDev/KataLLMAndroid/add-screenshots/screenshots/screenshot1.png" width="300"/> | <img src="https://raw.githubusercontent.com/voghDev/KataLLMAndroid/add-screenshots/screenshots/screenshot2.png" width="300"/> |

### New files
- `features/home/data/Llm.kt` - Data model
- `features/home/data/LlmDataSource.kt` - Stub data source with hardcoded LLMs
- `features/home/ui/HomeViewModel.kt` - ViewModel with sealed HomeUiState
- `features/home/ui/HomeScreen.kt` - LazyColumn-based list screen
- `features/llmdetail/ui/LlmDetailViewModel.kt` - Detail ViewModel
- `features/llmdetail/ui/LlmDetailScreen.kt` - Detail screen with Card layout
- `HomeViewModelTest.kt` - Unit tests

### Modified files
- `MainActivity.kt` - Removed Greeting composable, updated AppNavigation call
- `AppNavigation.kt` - Added LLM_DETAIL route with index nav argument

Closes #7

## Test plan
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Debug APK builds and installs on emulator (`./gradlew installDebug`)
- [x] Verify LLM list displays on home screen
- [x] Verify tapping an LLM navigates to detail screen with all fields
- [x] Verify back navigation from detail screen
- [x] Verify profile icon still navigates to profile screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)