### PR TITLE
feat: add central error handler via catchAndHandle Flow extension

### DIFF
--- a/.claude/agents/android-developer.md
+++ b/.claude/agents/android-developer.md
@@ -33,7 +33,7 @@ This agent works within a multi-agent setup, collaborating with other AI agents 
 
 ### Output to remote counterparts
 - We work with GitHub. For any Pull Request you create, make sure the repository is `KataLLMAndroid`.
-- When creating MRs, follow the template in `.github/pull_request_templates/`.
+- When creating PRs, follow the template in `.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md`.
 
 ### Project coding conventions
 - For shared project conventions, see `CLAUDE.md`.

--- a/.claude/agents/android-ui-developer.md
+++ b/.claude/agents/android-ui-developer.md
@@ -1,0 +1,52 @@
+## Agent: Android UI Developer (Devigner)
+
+### Role
+An experienced **Android Devigner** — a hybrid of designer and developer — purely focused on UI/UX for Android apps. This agent has deep knowledge of Jetpack Compose, XML layouts, Material Design, and motion/animation, but no context on architecture, networking, backend, or any concern beyond the visual layer.
+This agent works within a multi-agent setup, collaborating with other AI agents and human developers.
+
+### Responsibilities
+- **Design and implement Android screens and layouts** using Jetpack Compose or XML, following the latest Material Design 3 guidelines.
+- **Define and maintain the visual language** of the app: typography, color schemes, spacing, iconography, and component styles.
+- **Implement animations and transitions** between screens and UI elements using Compose animations or Android's Transition framework.
+- **Ensure accessibility** by applying proper content descriptions, touch target sizes, contrast ratios, and TalkBack support.
+- **Review UI-related Pull Requests**, focusing on visual correctness, component reuse, responsiveness across screen sizes, and adherence to design guidelines.
+- **Produce Composable previews** for all screens and components to allow visual inspection without running the app.
+- **Collaborate with other agents** on the visual output of features, translating requirements into pixel-perfect implementations.
+
+### Abilities
+- Has full access to the Android project's UI layer: Composables, XML layouts, theme files, drawable resources, and string resources.
+- Can read and write Jetpack Compose code (`@Composable` functions, `Modifier`, `LazyColumn`, `AnimatedVisibility`, etc.).
+- Can read and write XML layout files, styles, themes, and resource files.
+- Can produce and iterate on `@Preview` annotated Composables.
+- Can apply and extend Material3 theming (`MaterialTheme`, `ColorScheme`, `Typography`, `Shapes`).
+- Can implement animations using `animate*AsState`, `AnimatedContent`, `AnimatedVisibility`, `Transition`, and `MotionLayout`.
+- Can evaluate and improve UI for different screen sizes, orientations, and accessibility needs.
+
+### Out of Scope
+This agent has **no knowledge or responsibility** for:
+- Architecture patterns (MVVM, MVI, Clean Architecture)
+- ViewModels, UseCases, Repositories, or DataSources
+- Dependency injection (Hilt, Koin, Dagger)
+- Networking, REST APIs, or data parsing
+- Database or local storage
+- CI/CD pipelines, deployment, or release management
+- Unit or integration tests (UI snapshot tests are acceptable)
+
+### Communication Guidelines
+- Always write **technical responses in English**.
+- Use **named arguments and explicit typing** in all Kotlin/Compose examples to promote clarity.
+- When reviewing PRs, comment only on UI/UX concerns. Defer architectural feedback to other agents.
+
+### Example Prompts
+- "Implement a sectioned list grouping LLMs by company with sticky headers"
+- "Add an animated shimmer placeholder for the loading state on the Home screen"
+- "Review the Profile screen layout for spacing, typography, and accessibility issues"
+- "Create a dark theme variant for the app using Material3 dynamic color"
+- "Add a transition animation when navigating from the LLM list to the detail screen"
+
+### Output to remote counterparts
+- We work with GitHub. For any Pull Request you create, make sure the repository is `KataLLMAndroid`.
+- When creating PRs, follow the template in `.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md`.
+
+### Project coding conventions
+- For shared project conventions, see `CLAUDE.md`.

--- a/.claude/commands/complete-pr-checks.md
+++ b/.claude/commands/complete-pr-checks.md
@@ -1,0 +1,12 @@
+# Command: Complete PR checks
+
+When opening PRs, we normally add some checks to verify in the real Android device, such as
+
+[] check that the list of LLMs is shown
+[] check that tapping in one row of the list navigates to the detail
+
+The "Complete PR checks" command will mark all these checkboxes as done inside the most recently opened PR.
+The command checks for current context and assumes that the last opened PR will be the target PR.
+If there is no target PR, the command will list the last three PRs opened, sorted by date 
+(most recent to less recent), then the user will decide which PR to apply the command to.
+The command will also offer the option of applying to a different PR, none of the three listed above. 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ local.properties
 
 # Log/OS Files
 *.log
+.DS_Store
 
 # Android Studio generated files and folders
 captures/

--- a/app/src/main/java/es/voghdev/katallmandroid/core/FlowExtensions.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/core/FlowExtensions.kt
@@ -1,0 +1,12 @@
+package es.voghdev.katallmandroid.core
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+
+fun <T> Flow<T>.catchAndHandle(
+    onError: (Throwable) -> Unit,
+    action: suspend (Throwable) -> Unit,
+): Flow<T> = catch { e ->
+    onError(e)
+    action(e)
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/core/di/ErrorHandlingModule.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/core/di/ErrorHandlingModule.kt
@@ -1,0 +1,16 @@
+package es.voghdev.katallmandroid.core.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ErrorHandlingModule {
+
+    @Provides
+    fun provideErrorHandler(): @JvmSuppressWildcards (Throwable) -> Unit = { e ->
+        e.printStackTrace()
+    }
+}

--- a/app/src/test/java/es/voghdev/katallmandroid/features/home/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/es/voghdev/katallmandroid/features/home/ui/HomeViewModelTest.kt
@@ -29,6 +29,7 @@ class HomeViewModelTest {
     private lateinit var llmDataSource: LlmDataSource
     private lateinit var profileDataSource: ProfileDataSource
     private lateinit var subscriptionDataSource: SubscriptionDataSource
+    private val onError: (Throwable) -> Unit = {}
     private lateinit var viewModel: HomeViewModel
 
     private val mockLlms = listOf(
@@ -59,7 +60,7 @@ class HomeViewModelTest {
         givenThereAreSomeLlms()
         givenTheUserProfileReturns(mockUser)
         givenTheUserHasSubscription(UserSubscription.FREE)
-        viewModel = HomeViewModel(llmDataSource, profileDataSource, subscriptionDataSource)
+        viewModel = HomeViewModel(llmDataSource, profileDataSource, subscriptionDataSource, onError)
 
         viewModel.uiState.test {
             val state = awaitItem()
@@ -72,7 +73,7 @@ class HomeViewModelTest {
         givenThereAreSomeLlms()
         givenTheUserProfileReturns(mockUser)
         givenTheUserHasSubscription(UserSubscription.FREE)
-        viewModel = HomeViewModel(llmDataSource, profileDataSource, subscriptionDataSource)
+        viewModel = HomeViewModel(llmDataSource, profileDataSource, subscriptionDataSource, onError)
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.uiState.test {
@@ -90,7 +91,7 @@ class HomeViewModelTest {
         givenThereAreNoLlms()
         givenTheUserProfileReturns(mockUser)
         givenTheUserHasSubscription(UserSubscription.FREE)
-        viewModel = HomeViewModel(llmDataSource, profileDataSource, subscriptionDataSource)
+        viewModel = HomeViewModel(llmDataSource, profileDataSource, subscriptionDataSource, onError)
         testDispatcher.scheduler.advanceUntilIdle()
 
         viewModel.uiState.test {


### PR DESCRIPTION
## Summary
- Add `catchAndHandle` Flow extension function in `core` package — wraps `.catch`, calls the error tracking function first, then executes the caller's lambda for UI state updates
- Add `ErrorHandlingModule` providing a `(Throwable) -> Unit` via Hilt (currently logs via `printStackTrace`, ready to swap for Sentry/Crashlytics)
- Update `HomeViewModel` to inject `onError` and replace `.catch` with `.catchAndHandle`
- Update `HomeViewModelTest` to pass a no-op `onError` lambda

### Boy scout
- Add `.DS_Store` to `.gitignore`
- Fix pull request template path in agent markdown files (wrong casing and missing filename)
- Rewrite `android-ui-developer` agent as a devigner focused purely on UI/UX
- Add a new command to mark checkboxes as checked in PRs

Closes #14

## Test plan
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] App builds and installs correctly on device/emulator
- [x] Check that the list of LLMs is shown
- [x] Check that tapping in one row of the list navigates to the detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)