### PR TITLE
fix: prevent white screen on fast back tap

### DIFF
--- a/app/src/main/java/es/voghdev/katallmandroid/core/NavControllerExtensions.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/core/NavControllerExtensions.kt
@@ -1,0 +1,9 @@
+package es.voghdev.katallmandroid.core
+
+import androidx.navigation.NavController
+
+fun NavController.popBackStack(ifCurrentRoute: String) {
+    if (currentDestination?.route == ifCurrentRoute) {
+        popBackStack()
+    }
+}

--- a/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
@@ -32,7 +32,13 @@ fun AppNavigation(
             )
         }
         composable(Routes.PROFILE) {
-            ProfileScreen(onNavigateBack = { navController.popBackStack() })
+            ProfileScreen(
+                onNavigateBack = {
+                    if (navController.currentDestination?.route == Routes.PROFILE) {
+                        navController.popBackStack()
+                    }
+                },
+            )
         }
         composable(
             route = Routes.LLM_DETAIL,
@@ -41,7 +47,11 @@ fun AppNavigation(
             val llmIndex = backStackEntry.arguments?.getInt("llmIndex") ?: 0
             LlmDetailScreen(
                 llmIndex = llmIndex,
-                onNavigateBack = { navController.popBackStack() },
+                onNavigateBack = {
+                    if (navController.currentDestination?.route == Routes.LLM_DETAIL) {
+                        navController.popBackStack()
+                    }
+                },
             )
         }
     }

--- a/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
+++ b/app/src/main/java/es/voghdev/katallmandroid/navigation/AppNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import es.voghdev.katallmandroid.core.popBackStack
 import es.voghdev.katallmandroid.features.llmdetail.ui.LlmDetailScreen
 import es.voghdev.katallmandroid.features.profile.ui.ProfileScreen
 
@@ -33,11 +34,7 @@ fun AppNavigation(
         }
         composable(Routes.PROFILE) {
             ProfileScreen(
-                onNavigateBack = {
-                    if (navController.currentDestination?.route == Routes.PROFILE) {
-                        navController.popBackStack()
-                    }
-                },
+                onNavigateBack = { navController.popBackStack(ifCurrentRoute = Routes.PROFILE) },
             )
         }
         composable(
@@ -47,11 +44,7 @@ fun AppNavigation(
             val llmIndex = backStackEntry.arguments?.getInt("llmIndex") ?: 0
             LlmDetailScreen(
                 llmIndex = llmIndex,
-                onNavigateBack = {
-                    if (navController.currentDestination?.route == Routes.LLM_DETAIL) {
-                        navController.popBackStack()
-                    }
-                },
+                onNavigateBack = { navController.popBackStack(ifCurrentRoute = Routes.LLM_DETAIL) },
             )
         }
     }


### PR DESCRIPTION
## Summary
- Guard each `popBackStack()` call in `AppNavigation` by checking `navController.currentDestination?.route` before popping
- Extract the guard into a `NavController.popBackStack(ifCurrentRoute)` extension function in `core/NavControllerExtensions.kt`
- Applied to both Profile and LlmDetail back navigation

## Root cause
Tapping the back button quickly fires the `onClick` lambda multiple times before Compose Navigation processes the first pop. With only `home → profile` on the stack, a double-pop removes the root destination, leaving the `NavHost` with no active screen — resulting in a white blank screen that persists even after returning from the Android home screen.

## Fix
```kotlin
onNavigateBack = { navController.popBackStack(ifCurrentRoute = Routes.PROFILE) }
```
If `popBackStack()` has already been called and navigation has started, `currentDestination` will no longer match, so subsequent rapid taps are safely ignored.

Closes #16

## Test plan
- [x] Navigate to Profile and tap back quickly (multiple fast taps) — Home screen should remain visible
- [x] Navigate to LLM detail and tap back quickly — Home screen should remain visible
- [x] Normal (slow) back navigation still works correctly on both screens
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)